### PR TITLE
Add `main` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "author": "Frenco <hey@frenco.dev>",
   "type": "module",
+  "main": "dist/index.js",
   "exports": "./dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
After installing v2 in a React app, ESLint throws an `Unable to resolve path to module 'fenceparser'` error. The app/package works as expected. It seems that the removal of `"main": "dist/index.js"` that was present in v1 is causing the error, as downgrading from v2 to v1 resolves this linter error.

Environment:
- node v.14.17.3
- npm v6.14.13
- eslint v7.10.0
- @trevorblades/eslint-config v7.2.1
- eslint-plugin-cypress v2.11.2
- eslint-plugin-jsx-ally v6.4.1
- eslint-plugin-mdx v1.9.1

ESLint config:

```json
{
    "extends": [
        "@trevorblades/eslint-config/react",
        "plugin:jsx-a11y/recommended",
        "plugin:mdx/recommended"
    ],
    "plugins": [
        "custom-rules"
    ],
    "overrides": [
        {
            "files": [
                "**/*.mdx"
            ],
            "rules": {
                "react/no-unescaped-entities": "off",
                "no-unused-expressions": "off",
                "custom-rules/no-duplicate-task-ids": "error",
                "react/jsx-no-undef": "off",
                "mdx/no-unescaped-entities": "off"
            }
        },
        {
            "files": [
                "**/__tests__/*.js",
                "**/__tests__/*.jsx",
                "**.test.js"
            ],
            "env": {
                "jest": true
            }
        }
    ]
}
```