### PR TITLE
chore: handle dots in unquoted attribute values

### DIFF
--- a/src/lex.ts
+++ b/src/lex.ts
@@ -6,7 +6,7 @@ const OPS = /[{}[\]=,:]/
 const QUOTES = /["']/
 const ALPHAS = /[a-zA-Z_$-]/
 const NUMBERS = /[0-9]/
-const ALPHANUMERIC = /[a-zA-Z_$-]|[0-9]/
+const ALPHANUMERIC = /[a-zA-Z_$-.]|[0-9]/
 
 type Input = string
 type Output = Array<string | number>

--- a/test/cases.ts
+++ b/test/cases.ts
@@ -92,10 +92,15 @@ const cases = [
   },
   // Unquoted strings (only works for those without spaces)
   {
-    input: ['attr1=value1', 'attr2=--variable-names-like-css'],
+    input: [
+      'attr1=value1',
+      'attr2=--variable-names-like-css',
+      'attr3=with.dots.ext',
+    ],
     output: {
       attr1: 'value1',
       attr2: '--variable-names-like-css',
+      attr3: 'with.dots.ext',
     },
   },
   // Highlight Object (object literal without an attribute name)


### PR DESCRIPTION
When trying to parse an unquoted attribute value with a dot the lexer throws an error due to unexpected token.

e.g.
`ini {1-3,5} filename=config.ini`